### PR TITLE
#164977350 Implement Change Password Functionality

### DIFF
--- a/api/src/dto/change-password.dto.ts
+++ b/api/src/dto/change-password.dto.ts
@@ -1,0 +1,15 @@
+import { MinLength, IsNotEmpty } from 'class-validator';
+
+export class ChangePasswordDTO {
+  @MinLength(6)
+  @IsNotEmpty()
+  currentPassword: string;
+
+  @MinLength(6)
+  @IsNotEmpty()
+  newPassword: string;
+
+  @MinLength(6)
+  @IsNotEmpty()
+  confirmPassword: string;
+}

--- a/api/src/user/user.controller.ts
+++ b/api/src/user/user.controller.ts
@@ -7,6 +7,8 @@ import { UserService } from './user.service';
 import { LoginDTO } from 'src/dto/login.dto';
 import { SignupDTO } from 'src/dto/signup.dto';
 import { AuthGuard } from 'src/shared/auth.guard';
+import { ChangePasswordDTO } from 'src/dto/change-password.dto';
+import { User } from 'src/decorators/user.decorator';
 
 @Controller(`${process.env.BASE_PATH}/auth`)
 export class UserController {
@@ -41,5 +43,18 @@ export class UserController {
   @UseGuards(new AuthGuard())
   logout(@Req() request: Request) {
     return this.userService.logout(request);
+  }
+
+  @Post('/change-password')
+  @UseGuards(new AuthGuard())
+  @UsePipes(new ValidationPipe())
+  changePassword(@Req() request: Request, @User('id') user: string, @Body() data: ChangePasswordDTO) {
+    FileLogger.log({
+      method: 'POST',
+      user,
+      data,
+    });
+    this.logger.log(`${JSON.stringify({ method: 'POST', user, data })}`);
+    return this.userService.changePassword(request, user, data);
   }
 }


### PR DESCRIPTION
### What does this PR do?
* Add change password functionality to Memoire REST API
#### Description of Task to be completed?
Get the following endpoint working:
* ```POST /api/v1/auth/change-password```
#### How should this be manually tested?
* Clone this repository and checkout to this branch (ft/164977350/change-password-endpoint).
* Install the Postgres database by following the instruction on the README.
* Install the depedencies by running npm install
* Run the application in development by running npm run start:dev
* Using a REST Client such as Postman, create a user account to get the token.
With the token passed as a request authorization header, test the endpoint above with appropriate request body.
#### What are the relevant pivotal tracker stories?
#164977350