### PR TITLE
#164977370 Delete User Account Endpoint for Memoire API

### DIFF
--- a/api/src/dto/delete-account.dto.ts
+++ b/api/src/dto/delete-account.dto.ts
@@ -1,0 +1,7 @@
+import { MinLength, IsNotEmpty } from 'class-validator';
+
+export class DeleteAccountDTO {
+  @MinLength(6)
+  @IsNotEmpty()
+  password: string;
+}

--- a/api/src/user/user.controller.ts
+++ b/api/src/user/user.controller.ts
@@ -1,4 +1,16 @@
-import { Controller, Post, Body, UsePipes, Logger, Get, UseGuards, Req, Query, Put } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  UsePipes,
+  Logger,
+  Get,
+  UseGuards,
+  Req,
+  Query,
+  Put,
+  Delete,
+} from '@nestjs/common';
 import { Request } from 'express';
 
 import { UserService } from './user.service';
@@ -12,10 +24,10 @@ import { ChangePasswordDTO } from 'src/dto/change-password.dto';
 import { ForgotPasswordDTO } from 'src/dto/forgot-password.dto';
 import { ResetPasswordDTO } from 'src/dto/reset-password.dto';
 import { AccountDTO } from 'src/dto/account.dto';
+import { DeleteAccountDTO } from 'src/dto/delete-account.dto';
 
 @Controller(`${process.env.BASE_PATH}/auth`)
 export class UserController {
-
   constructor(private userService: UserService) {}
 
   private logger = new Logger('UserController');
@@ -51,7 +63,11 @@ export class UserController {
   @Post('/change-password')
   @UseGuards(new AuthGuard())
   @UsePipes(new ValidationPipe())
-  changePassword(@Req() request: Request, @User('id') user: string, @Body() data: ChangePasswordDTO) {
+  changePassword(
+    @Req() request: Request,
+    @User('id') user: string,
+    @Body() data: ChangePasswordDTO,
+  ) {
     FileLogger.log({
       method: 'POST',
       user,
@@ -95,5 +111,21 @@ export class UserController {
     });
     this.logger.log(`${JSON.stringify({ method: 'POST', user, data })}`);
     return this.userService.updateAccount(user, data);
+  }
+
+  @Delete('/account')
+  @UseGuards(new AuthGuard())
+  @UsePipes(new ValidationPipe())
+  deleteAccount(
+    @Req() request: Request,
+    @User('id') user: string,
+    @Body() data: DeleteAccountDTO,
+  ) {
+    FileLogger.log({
+      method: 'PUT',
+      user,
+    });
+    this.logger.log(`${JSON.stringify({ method: 'POST', user })}`);
+    return this.userService.deleteAccount(request, user, data);
   }
 }

--- a/api/src/user/user.module.ts
+++ b/api/src/user/user.module.ts
@@ -4,9 +4,12 @@ import { UserEntity } from './user.entity';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { LogoutTokenEntity } from './logout-token.entity';
+import { EntryEntity } from 'src/entry/entry.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity, LogoutTokenEntity])],
+  imports: [
+    TypeOrmModule.forFeature([UserEntity, LogoutTokenEntity, EntryEntity]),
+  ],
   controllers: [UserController],
   providers: [UserService],
 })


### PR DESCRIPTION
### What does this PR do?
- Add endpoint to delete user's account
#### Description of Task to be completed?
- Get the endpoint ```DELETE /api/v1/auth/account``` working
#### How should this be manually tested?
* Clone this repository and checkout to this branch (ft/164977370/delete-account-endpoint).
* Install the Postgres database by following the instruction on the README.
* Install the depedencies by running ```npm install```
* Run the application in development by running ```npm run start:dev```
* Using a REST Client such as Postman, create a user account to get the token.
* With the token passed as a request authorization header, create a couple of entries.
* Finally, test the endpoint above passing in the password for the created account as a request body.
#### What are the relevant pivotal tracker stories?
#164977370